### PR TITLE
Add nested device move test

### DIFF
--- a/src/caspi/torch/helpers.py
+++ b/src/caspi/torch/helpers.py
@@ -54,8 +54,11 @@ def _arrow_batch_to_tensor_dict(
         TensorDict: A dictionary where keys are column names (or derived names
             for tokenized strings) and values are either `torch.Tensor` (for
             scalar types, timestamps, tokenized strings) or `list[torch.Tensor]`
-            (for array types). Returns an empty dictionary if the input
-            `record_batch` has zero rows.
+            (for arrays of numeric, boolean, or timestamp types). For string
+            arrays, each element of the list can instead be a dictionary
+            containing the tokenized tensors (e.g., ``{"input_ids": ..., "attention_mask": ...}``).
+            Returns an empty dictionary if the input `record_batch` has zero
+            rows.
 
     Raises:
         TypeError: If a column contains a data type that is not supported for
@@ -281,7 +284,7 @@ def _concatenate_tensor_dicts(dict1: TensorDict, dict2: TensorDict) -> TensorDic
                 # For tokenizer outputs (dictionaries), combine the lists
                 concatenated[key] = val1 + val2
             else:
-                # Harmonise devices for each tensor within the lists
+                # Harmonize devices for each tensor within the lists
                 target_device = (
                     val1[0].device
                     if val1
@@ -469,13 +472,10 @@ def _to_device(tensor_dict: TensorDict, device: str | torch.device | None) -> Te
     def _move_item(item: Any) -> Any:
         if isinstance(item, torch.Tensor):
             return item.to(device)
+        if isinstance(item, list):
+            return [_move_item(v) for v in item]
         if isinstance(item, dict):
             return {k: _move_item(v) for k, v in item.items()}
-        if isinstance(item, list):
-            return [
-                _move_item(v) if isinstance(v, (torch.Tensor, dict, list)) else v
-                for v in item
-            ]
         return item
 
     result: TensorDict = {}

--- a/tests/caspi/test_torch.py
+++ b/tests/caspi/test_torch.py
@@ -1313,6 +1313,20 @@ def test_to_device() -> None:
     assert cast(list, moved_mixed_list_dict["e"])[1] == "string"
     assert cast(list, moved_mixed_list_dict["e"])[2].device == target_device
 
+    # Test with list containing dictionaries of tensors
+    dict_list_dict: TensorDict = {
+        "f": [
+            {"x": torch.tensor([1], device=initial_device)},
+            {"y": torch.tensor([2, 3], device=initial_device)},
+        ]
+    }
+    moved_dict_list_dict = _to_device(dict_list_dict, target_device_str)
+    assert isinstance(moved_dict_list_dict["f"], list)
+    assert cast(dict, moved_dict_list_dict["f"][0])["x"].device == target_device
+    assert torch.equal(cast(dict, moved_dict_list_dict["f"][0])["x"], torch.tensor([1]))
+    assert cast(dict, moved_dict_list_dict["f"][1])["y"].device == target_device
+    assert torch.equal(cast(dict, moved_dict_list_dict["f"][1])["y"], torch.tensor([2, 3]))
+
 
 def test_serialise_batches() -> None:
     """Tests the _serialise_batches helper function.


### PR DESCRIPTION
## Summary
- move nested tokenizer dictionaries to specified device
- test that _to_device handles nested tokenizer-output dictionaries

## Testing
- `python -m py_compile src/caspi/torch/helpers.py tests/caspi/test_torch.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyspark')*

------
https://chatgpt.com/codex/tasks/task_e_684035164f0c83239b9468b093d4ad8e